### PR TITLE
Add server log for crashes

### DIFF
--- a/taqo_client/macos/TaqoLauncher/AppDelegate.swift
+++ b/taqo_client/macos/TaqoLauncher/AppDelegate.swift
@@ -14,6 +14,7 @@
 
 import Cocoa
 import Darwin
+import Foundation
 
 @NSApplicationMain
 class AppDelegate: NSObject, NSApplicationDelegate {
@@ -44,6 +45,25 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     task.executableURL = URL(fileURLWithPath: taqoDaemon.absoluteString)
     task.arguments = []
     task.standardInput = pty
+
+    if let outUrl = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first?.appendingPathComponent("com.taqo/server.out", isDirectory: false) {
+      if !FileManager.default.fileExists(atPath: outUrl.path) {
+        FileManager.default.createFile(atPath: outUrl.path, contents: nil)
+      }
+      if let outFile = try? FileHandle.init(forWritingTo: outUrl) {
+        task.standardOutput = outFile
+      }
+    }
+
+    if let errUrl = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first?.appendingPathComponent("com.taqo/server.err", isDirectory: false) {
+      if !FileManager.default.fileExists(atPath: errUrl.path) {
+        FileManager.default.createFile(atPath: errUrl.path, contents: nil)
+      }
+      if let errFile = try? FileHandle.init(forWritingTo: errUrl) {
+        task.standardError = errFile
+      }
+    }
+
     do {
       try task.run()
     } catch {


### PR DESCRIPTION
Ideally, all the server logs should go to the one used by Taqo's logging
service, i.e. server-yyyy-MM-dd.log, which is managed within Dart.
However, it might be not straightforward to catch fatal errors from
within Dart. Since taqo_daemon is now called from TaqoLauncher, we could
redirect taqo_daemon's stdout and stderr to different log files. Again,
these stdout and stderr logs ideally should be managed by some rotation
strategy. However, keeping the stdout and stderr only for the latest run
is much simpler to implement and enough for our current debugging
activities. Hence that is the way I pick here.