### PR TITLE
Changed linux and macos artifacts upload directory to the root

### DIFF
--- a/kokoro/gcp_ubuntu/continuous.cfg
+++ b/kokoro/gcp_ubuntu/continuous.cfg
@@ -24,5 +24,7 @@ action {
     regex: "github/taqo-paco-kokoro/distribution/build/**deb**"
     regex: "github/taqo-paco-kokoro/distribution/build/**changes**"
     regex: "github/taqo-paco-kokoro/distribution/build/**buildinfo**"
+    strip_prefix: "github/taqo-paco-kokoro/distribution/build/"
+    fail_if_no_artifacts: true
   }
 }

--- a/kokoro/gcp_ubuntu/presubmit.cfg
+++ b/kokoro/gcp_ubuntu/presubmit.cfg
@@ -24,5 +24,7 @@ action {
     regex: "github/taqo-paco-kokoro/distribution/build/**deb**"
     regex: "github/taqo-paco-kokoro/distribution/build/**changes**"
     regex: "github/taqo-paco-kokoro/distribution/build/**buildinfo**"
+    strip_prefix: "github/taqo-paco-kokoro/distribution/build/"
+    fail_if_no_artifacts: true
   }
 }

--- a/kokoro/macos_external/continuous.cfg
+++ b/kokoro/macos_external/continuous.cfg
@@ -24,5 +24,7 @@ action {
      regex: "github/taqo-paco-kokoro/taqo_client/build/macos/Build/Products/Release/*.zip"
      regex: "github/taqo-paco-kokoro/taqo_client/build/macos/Build/Products/Release/*.app"
      regex: "github/taqo-paco-kokoro/taqo_client/build/macos/Build/Products/Release/*"
+     strip_prefix: "github/taqo-paco-kokoro/taqo_client/build/macos/Build/Products/Release/"
+     fail_if_no_artifacts: true
   }
 }

--- a/kokoro/macos_external/presubmit.cfg
+++ b/kokoro/macos_external/presubmit.cfg
@@ -24,5 +24,7 @@ action {
      regex: "github/taqo-paco-kokoro/taqo_client/build/macos/Build/Products/Release/*.zip"
      regex: "github/taqo-paco-kokoro/taqo_client/build/macos/Build/Products/Release/*.app"
      regex: "github/taqo-paco-kokoro/taqo_client/build/macos/Build/Products/Release/*"
+     strip_prefix: "github/taqo-paco-kokoro/taqo_client/build/macos/Build/Products/Release/"
+     fail_if_no_artifacts: true
   }
 }


### PR DESCRIPTION
This PR is to change the CI linux and macOS build artifacts upload directory to the root folder of the kokoro build directory in placer. 
Before this PR, the uploaded artifacts used to reside in the relative path from the project folder where the artifact was built during the build process. 
For example, before this PR the path to the artifact would be: 
`/placer/prod/home/kokoro-dedicated/build_artifacts/prod/taqo/gcp_ubuntu/continuous/<build id and number>/github/taqo-paco-kokoro/distribution/build/`
that will now be:
`/placer/prod/home/kokoro-dedicated/build_artifacts/prod/taqo/gcp_ubuntu/continuous/<build id and number>/` 