### PR TITLE
Handle TespRequestPalLogCmd in pal_event_server

### DIFF
--- a/pal_event_server/lib/src/loggers/pal_event_helper.dart
+++ b/pal_event_server/lib/src/loggers/pal_event_helper.dart
@@ -120,6 +120,9 @@ Future<Event> createAppUsagePacoEvent(Experiment experiment, String groupName,
   return event;
 }
 
+// TODO(https://github.com/google/taqo-paco/issues/56):
+// Remove createCmdUsagePacoEvent and use createShellUsagePacoEvent below instead, after
+// we migrate to the new shell usage tracer.
 //const _uidKey = 'uid';
 const _pidKey = 'pid';
 const cmdRawKey = 'cmd_raw';
@@ -135,6 +138,13 @@ Future<Event> createCmdUsagePacoEvent(Experiment experiment, String groupName,
     cmdRawKey: response[cmdRawKey].trim(),
   };
   event.responses.addAll(responses);
+  return event;
+}
+
+Future<Event> createShellUsagePacoEvent(Experiment experiment, String groupName,
+    Map<String, dynamic> response) async {
+  final event = await _createPacoEvent(experiment, groupName);
+  event.responses.addAll(response);
   return event;
 }
 

--- a/pal_event_server/lib/src/tesp_server.dart
+++ b/pal_event_server/lib/src/tesp_server.dart
@@ -19,6 +19,7 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:pal_event_server/src/experiment_cache.dart';
+import 'package:pal_event_server/src/loggers/cmd_line/cmdline_logger.dart';
 import 'package:pal_event_server/src/loggers/loggers.dart' as loggers;
 
 import 'package:pedantic/pedantic.dart';
@@ -27,6 +28,7 @@ import 'package:taqo_common/model/event.dart';
 import 'package:taqo_common/model/experiment.dart';
 import 'package:taqo_common/model/experiment_group.dart';
 import 'package:taqo_common/model/notification_holder.dart';
+import 'package:taqo_common/model/shell_command_log.dart';
 import 'package:taqo_common/service/experiment_service_lite.dart';
 import 'package:taqo_common/service/sync_service.dart';
 import 'package:taqo_event_server_protocol/taqo_event_server_protocol.dart';
@@ -136,8 +138,10 @@ class PALTespServer with TespRequestHandlerMixin {
   }
 
   @override
-  Future<TespResponse> palLogCmd(ShellCommandLog) async {
-    throw UnimplementedError();
+  TespResponse palLogCmd(ShellCommandLog cmdLog) {
+    final shellLogger = CmdLineLogger();
+    shellLogger.addLog(cmdLog);
+    return TespResponseSuccess();
   }
 
   @override

--- a/pal_event_server/pubspec.lock
+++ b/pal_event_server/pubspec.lock
@@ -42,14 +42,14 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.4.0"
+    version: "2.8.2"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.1.0"
   charcode:
     dependency: transitive
     description:
@@ -99,13 +99,20 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.1.2"
+  file:
+    dependency: transitive
+    description:
+      name: file
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "6.1.4"
   glob:
     dependency: transitive
     description:
       name: glob
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "2.0.1"
   googleapis:
     dependency: transitive
     description:
@@ -161,7 +168,7 @@ packages:
       name: js
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.6.1+1"
+    version: "0.6.3"
   json_annotation:
     dependency: transitive
     description:
@@ -182,7 +189,7 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.9"
+    version: "0.12.10"
   meta:
     dependency: "direct overridden"
     description:
@@ -197,20 +204,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.0"
-  node_interop:
-    dependency: transitive
-    description:
-      name: node_interop
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.1.1"
-  node_io:
-    dependency: transitive
-    description:
-      name: node_io
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.1.1"
   node_preamble:
     dependency: transitive
     description:
@@ -231,14 +224,14 @@ packages:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.6.4"
+    version: "1.8.3"
   pedantic:
     dependency: "direct main"
     description:
       name: pedantic
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.9.0"
+    version: "1.11.1"
   petitparser:
     dependency: transitive
     description:
@@ -252,7 +245,7 @@ packages:
       name: pool
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.4.0"
+    version: "1.5.1"
   pub_semver:
     dependency: transitive
     description:
@@ -301,21 +294,21 @@ packages:
       name: source_map_stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.1.1"
   source_maps:
     dependency: transitive
     description:
       name: source_maps
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.10.9"
+    version: "0.10.10"
   source_span:
     dependency: transitive
     description:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.6.0"
+    version: "1.8.1"
   sqlite3:
     dependency: "direct main"
     description:
@@ -329,21 +322,21 @@ packages:
       name: stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.9.6"
+    version: "1.10.0"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.1.0"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.5"
+    version: "1.1.1"
   synchronized:
     dependency: transitive
     description:
@@ -378,35 +371,35 @@ packages:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.1"
   test:
     dependency: "direct dev"
     description:
       name: test
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.15.7"
+    version: "1.16.5"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.18+1"
+    version: "0.2.19"
   test_core:
     dependency: transitive
     description:
       name: test_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.11+4"
+    version: "0.3.15"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.6"
+    version: "1.3.1"
   vm_service:
     dependency: transitive
     description:

--- a/taqo_client/pubspec.lock
+++ b/taqo_client/pubspec.lock
@@ -35,7 +35,7 @@ packages:
       name: args
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.2.0"
+    version: "2.3.1"
   async:
     dependency: transitive
     description:
@@ -63,7 +63,7 @@ packages:
       name: build_config
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.5"
+    version: "0.4.6"
   build_daemon:
     dependency: transitive
     description:
@@ -84,28 +84,28 @@ packages:
       name: build_runner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.11.1+1"
+    version: "1.11.5"
   build_runner_core:
     dependency: transitive
     description:
       name: build_runner_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.1.7"
+    version: "6.1.10"
   built_collection:
     dependency: transitive
     description:
       name: built_collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.1.0"
+    version: "5.1.1"
   built_value:
     dependency: transitive
     description:
       name: built_value
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "8.1.2"
+    version: "8.4.3"
   cached_network_image:
     dependency: "direct main"
     description:
@@ -140,7 +140,7 @@ packages:
       name: cli_util
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.3"
+    version: "0.3.5"
   clock:
     dependency: transitive
     description:
@@ -217,21 +217,21 @@ packages:
       name: ffi
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.2"
+    version: "1.2.1"
   file:
     dependency: transitive
     description:
       name: file
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.2.1"
+    version: "6.1.4"
   fixnum:
     dependency: transitive
     description:
       name: fixnum
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.0"
+    version: "1.0.1"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -288,7 +288,7 @@ packages:
       name: glob
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "2.0.1"
   googleapis:
     dependency: transitive
     description:
@@ -407,7 +407,7 @@ packages:
       name: mime
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.0"
+    version: "1.0.3"
   nested:
     dependency: transitive
     description:
@@ -415,20 +415,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.0"
-  node_interop:
-    dependency: transitive
-    description:
-      name: node_interop
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.2.1"
-  node_io:
-    dependency: transitive
-    description:
-      name: node_io
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.2.0"
   numberpicker:
     dependency: "direct main"
     description:
@@ -512,7 +498,7 @@ packages:
       name: platform
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.2"
+    version: "3.1.0"
   plugin_platform_interface:
     dependency: transitive
     description:
@@ -526,14 +512,14 @@ packages:
       name: pool
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.5.0"
+    version: "1.5.1"
   process:
     dependency: transitive
     description:
       name: process
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.13"
+    version: "4.2.4"
   provider:
     dependency: "direct main"
     description:
@@ -547,7 +533,7 @@ packages:
       name: pub_semver
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.1.2"
   pubspec_parse:
     dependency: transitive
     description:
@@ -783,7 +769,7 @@ packages:
       name: win32
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.2.5"
+    version: "2.2.10"
   workmanager:
     dependency: "direct main"
     description:
@@ -804,7 +790,7 @@ packages:
       name: yaml
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.1.0"
+    version: "3.1.1"
 sdks:
-  dart: ">=2.13.0 <3.0.0"
+  dart: ">=2.14.0-0 <3.0.0"
   flutter: ">=1.22.2"

--- a/taqo_common/lib/model/shell_command_log.dart
+++ b/taqo_common/lib/model/shell_command_log.dart
@@ -20,10 +20,11 @@ part 'shell_command_log.g.dart';
 
 abstract class ShellCommandLog {
   String get type;
+  Map<String, dynamic> toJson();
 }
 
 @JsonSerializable()
-class ShellCommandStart extends ShellCommandLog {
+class ShellCommandStart implements ShellCommandLog {
   @override
   final type = 'start';
 
@@ -45,12 +46,13 @@ class ShellCommandStart extends ShellCommandLog {
   // Once we migrated to null-safe Dart, we can upgrade json_annotation to 4.8.0 or higher,
   // where we can force `type` to be serialized and does not need to manually append key-value pairs.
   // See also https://github.com/google/json_serializable.dart/issues/274
+  @override
   Map<String, dynamic> toJson() =>
       _$ShellCommandStartToJson(this)..putIfAbsent('type', () => this.type);
 }
 
 @JsonSerializable()
-class ShellCommandEnd extends ShellCommandLog {
+class ShellCommandEnd implements ShellCommandLog {
   @override
   final type = 'end';
 
@@ -70,6 +72,7 @@ class ShellCommandEnd extends ShellCommandLog {
   // Once we migrated to null-safe Dart, we can upgrade json_annotation to 4.8.0 or higher,
   // where we can force `type` to be serialized and does not need to manually append key-value pairs.
   // See also https://github.com/google/json_serializable.dart/issues/274
+  @override
   Map<String, dynamic> toJson() =>
       _$ShellCommandEndToJson(this)..putIfAbsent('type', () => this.type);
 }


### PR DESCRIPTION
- Add API to the shell command logger to make it usable by a TespRequestPalLogCmd handler
- Implement TespRequestPalLogCmd handler in pal_event_server

Next to come in the series:

- Add a standalone binary that can send shell command traces to Taqo's event server
- Use preexec hooks and the standalone binary above in Taqo's shell command tracer/logger
