### PR TITLE
fix issue 171 make app usage logging more robust

### DIFF
--- a/pal_event_server/lib/src/loggers/app_usage/macos/macos_helper.dart
+++ b/pal_event_server/lib/src/loggers/app_usage/macos/macos_helper.dart
@@ -28,28 +28,33 @@ String _prevAppAndWindowName;
 // Run Apple Script for the active window
 void macOSAppLoggerIsolate(SendPort sendPort) {
   Timer.periodic(queryInterval, (Timer _) {
-    Process.run(apple_script.command, apple_script.scriptArgs).then((result) {
-      final currWindow = result.stdout.trim();
-      if (currWindow != '') {
-        final resultMap = apple_script.buildResultMap(currWindow);
-        final currAppAndWindowName =
-            resultMap[appNameField] + resultMap[windowNameField];
+    try {
+      Process.run(apple_script.command, apple_script.scriptArgs).then((result) {
+        final currWindow = result.stdout.trim();
+        if (currWindow != '') {
+          final resultMap = apple_script.buildResultMap(currWindow);
+          final currAppAndWindowName =
+              resultMap[appNameField] + resultMap[windowNameField];
 
-        if (currAppAndWindowName != _prevAppAndWindowName) {
-          // Send APP_CLOSED
-          if (_prevAppAndWindowName != null &&
-              _prevAppAndWindowName.isNotEmpty) {
-            sendPort.send(_prevAppAndWindowName);
-          }
+          if (currAppAndWindowName != _prevAppAndWindowName) {
+            // Send APP_CLOSED
+            if (_prevAppAndWindowName != null &&
+                _prevAppAndWindowName.isNotEmpty) {
+              sendPort.send(_prevAppAndWindowName);
+            }
 
-          _prevAppAndWindowName = currAppAndWindowName;
+            _prevAppAndWindowName = currAppAndWindowName;
 
-          // Send PacoEvent && APP_USAGE
-          if (resultMap != null) {
-            sendPort.send(resultMap);
+            // Send PacoEvent && APP_USAGE
+            if (resultMap != null) {
+              sendPort.send(resultMap);
+            }
           }
         }
-      }
-    });
+      });
+    } catch (e, s) {
+      print('Exception details:\n $e');
+      print('Stack trace:\n $s');
+    }
   });
 }


### PR DESCRIPTION
Found an opportunity to wrap the mac app logger to prevent crashes from taking down the timer