### PR TITLE
Make timestamp of tracer accurate to milliseconds

### DIFF
--- a/pal_event_server/lib/src/loggers/pal_event_helper.dart
+++ b/pal_event_server/lib/src/loggers/pal_event_helper.dart
@@ -70,6 +70,7 @@ Future<List<Event>> createLoggerPacoEvents(
 }
 
 const _participantId = 'participantId';
+const _timestamp = 'timestamp';
 
 Event createPacoEvent(Experiment experiment, String groupName) {
   var group;
@@ -84,7 +85,8 @@ Event createPacoEvent(Experiment experiment, String groupName) {
   event.responseTime = ZonedDateTime.now();
 
   event.responses = <String, dynamic>{
-    _participantId : '${experiment.participantId}',
+    _participantId: '${experiment.participantId}',
+    _timestamp: event.responseTime.toIso8601String(withColon: true)
   };
 
   return event;
@@ -106,7 +108,7 @@ Future<Event> createLoggerStatusPacoEvent(Experiment experiment,
 const appsUsedKey = 'apps_used';
 const appContentKey = 'app_content';
 const appsUsedRawKey = 'apps_used_raw';
-const _isIdleKey ='isIdle';
+const _isIdleKey = 'isIdle';
 
 final _allowList = createDefaultAllowList();
 

--- a/taqo_common/lib/model/shell_command_log.dart
+++ b/taqo_common/lib/model/shell_command_log.dart
@@ -78,7 +78,7 @@ class ShellCommandEnd implements ShellCommandLog {
 }
 
 ZonedDateTime _zonedDateTimeFromString(String string) =>
-    ZonedDateTime.fromString(string);
+    ZonedDateTime.fromIso8601String(string);
 
 String _zonedDateTimeToString(ZonedDateTime zonedDateTime) =>
-    zonedDateTime.toString();
+    zonedDateTime.toIso8601String(withColon: true);


### PR DESCRIPTION
Fixes part of  #221 

Now the accuracy of shell and desktop tracers would be milliseconds.